### PR TITLE
Add ability to exclude some directory of notifications

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -1,5 +1,6 @@
 <?php
 /* defaults */
 $rcmail_config['html5_notifier_duration'] = '3'; //Display duration of Desktop Notifications (0 = disabled)
-$rcmail_config['html5_notifier_smbox'] = '1'; //Lenght of displayed mailboxname 2=max 1=short 0=do not show
+$rcmail_config['html5_notifier_smbox'] = '1'; //Length of displayed mailboxname 2=max 1=short 0=do not show
+$rcmail_config['html5_notifier_excluded_directories'] = 'Trash' //Directories excluded for notifications. Use ; as separator for multiple directories;
 ?>

--- a/html5_notifier.php
+++ b/html5_notifier.php
@@ -32,7 +32,7 @@ class html5_notifier extends rcube_plugin
             $this->include_script("html5_notifier.js");
             if ($RCMAIL->action != 'check-recent')
             {
-                $this->add_texts('localization', array('notification_title', 'ok_notifications', 'no_notifications', 'check_ok', 'check_fail', 'check_fail_blocked')); //PRÄZESIEREN
+                $this->add_texts('localization', array('notification_title', 'ok_notifications', 'no_notifications', 'check_ok', 'check_fail', 'check_fail_blocked')); //PRï¿½ZESIEREN
             }
         }
     }
@@ -44,6 +44,7 @@ class html5_notifier extends rcube_plugin
 		$RCMAIL->storage->set_mailbox($args['mailbox']);
 		$RCMAIL->storage->search($args['mailbox'], "RECENT", null);
 		$msgs = (array) $RCMAIL->storage->list_headers($args['mailbox']);
+		$excluded_directories = explode(';', $RCMAIL->config->get('html5_notifier_excluded_directories'));
 
 		foreach ($msgs as $msg) {
 		    $from = $msg->get('from');
@@ -54,7 +55,7 @@ class html5_notifier extends rcube_plugin
 			}
 			$subject = ((!empty($mbox)) ? $mbox.': ' : '').$msg->get('subject');
 
-            if(strtolower($_SESSION['username']) == strtolower($RCMAIL->user->data['username']))
+            if(strtolower($_SESSION['username']) == strtolower($RCMAIL->user->data['username']) && !in_array($mbox, $excluded_directories))
             {
                 $RCMAIL->output->command("plugin.showNotification", array(
                     'duration' => $RCMAIL->config->get('html5_notifier_duration'),
@@ -95,8 +96,15 @@ class html5_notifier extends rcube_plugin
                 'title' => html::label($field_id, Q($this->gettext('shownotifies'))), 
                 'content' => $content,
             );
-            
-            $RCMAIL->output->add_script("$(document).ready(function(){ rcmail_browser_notifications_colorate(); });");            
+
+			$field_id .= '_excluded';
+			$input_excluded = new html_inputfield(array('name' => '_html5_notifier_excluded_directories', 'id' => $field_id));
+			$args['blocks']['new_message']['options']['html5_notifier_excluded_directories'] = array(
+                'title' => html::label($field_id, Q($this->gettext('excluded_directories'))),
+                'content' => $input_excluded->show($RCMAIL->config->get('html5_notifier_excluded_directories').''),
+            );
+
+            $RCMAIL->output->add_script("$(document).ready(function(){ rcmail_browser_notifications_colorate(); });");
         }
         return $args;
     }
@@ -107,6 +115,7 @@ class html5_notifier extends rcube_plugin
         {
             $args['prefs']['html5_notifier_duration'] = get_input_value('_html5_notifier_duration', RCUBE_INPUT_POST);
 			$args['prefs']['html5_notifier_smbox'] = get_input_value('_html5_notifier_smbox', RCUBE_INPUT_POST);
+			$args['prefs']['html5_notifier_excluded_directories'] = get_input_value('_html5_notifier_excluded_directories', RCUBE_INPUT_POST);
             return $args;
         }
     }

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -3,10 +3,11 @@ $labels = array();
 $labels['shownotifies'] = 'Desktop Benachrichtigungen';
 $labels['conf_browser'] = 'Browser einrichten';
 $labels['test_browser'] = 'Testen';
+$labels['excluded_directories'] = 'Ausgeschlossene verzeichnisse meldungen';
 $labels['check_ok'] = 'Ihre Browsereinstellungen sind korrekt.';
 $labels['check_fail'] = 'Es konnte keine Benachrichtigung angezeigt werden, bitte klicken Sie auf "Browser einrichten"!';
 $labels['check_fail_blocked'] = 'Ihr Browser hat die Benachrichtigung blockert, bitte erlauben Sie diese in den Einstellungen Ihres Browsers!';
-$labels['no_notifications'] = 'Ihr Browser unterstützt noch keine Desktop Benachrichtigungen!';
+$labels['no_notifications'] = 'Ihr Browser unterstï¿½tzt noch keine Desktop Benachrichtigungen!';
 $labels['ok_notifications'] = 'Die Website hat die Erlaubnis bereits erhalten. Desktop Benachrichtgungen sollten funktionieren.';
 $labels['notification_title'] = 'Neue E-Mail von [from]';
 

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -3,6 +3,7 @@ $labels = array();
 $labels['shownotifies'] = 'Desktop Notifications';
 $labels['conf_browser'] = 'Configure browser';
 $labels['test_browser'] = 'Test';
+$labels['excluded_directories'] = 'Notification\'s excluded directories';
 $labels['check_ok'] = 'Your browser settings are correct.';
 $labels['check_fail'] = 'It was not possible to show a notification, please click "Configure browser"!';
 $labels['check_fail_blocked'] = 'Your browser blocked the notification, please set the permission in the browser settings!';

--- a/localization/es_ES.inc
+++ b/localization/es_ES.inc
@@ -4,6 +4,7 @@ $labels = array();
 $labels['shownotifies'] = 'Notificaciones Escritorio';
 $labels['conf_browser'] = 'Configurar Navegador';
 $labels['test_browser'] = 'Test';
+$labels['excluded_directories'] = 'Directorios notificaciones Excluidos';
 $labels['check_ok'] = 'La configuración de tu Navegador es correcta.';
 $labels['check_fail'] = 'No fue posible mostrar la notificación, por favor haz clic en "Configurar Navegador"!';
 $labels['check_fail_blocked'] = 'Your browser blocked the notification, please set the permission in the browser settings!';

--- a/localization/fr_FR.inc
+++ b/localization/fr_FR.inc
@@ -3,6 +3,7 @@ $labels = array();
 $labels['shownotifies'] = 'Notifications de bureau';
 $labels['conf_browser'] = 'Configurer votre navigateur';
 $labels['test_browser'] = 'Test';
+$labels['excluded_directories'] = 'Répertoires exclus des notifications';
 $labels['check_ok'] = 'Les paramètres de votre navigateur sont corrects.';
 $labels['check_fail'] = 'Il n\'était pas possible d\'afficher les notifications, s\'il vous plaît cliquez sur "Configurer votre navigateur"!';
 $labels['check_fail_blocked'] = 'Votre navigateur a bloqué la notification, s\'il vous plaît autorisez-les dans les paramètres du navigateur!';

--- a/localization/sk_SK.inc
+++ b/localization/sk_SK.inc
@@ -3,6 +3,7 @@ $labels = array();
 $labels['shownotifies'] = 'Upozornenia na pracovnej ploche';
 $labels['conf_browser'] = 'Nakonfigurovať prehliadač';
 $labels['test_browser'] = 'Test';
+$labels['excluded_directories'] = 'Vylúčené adresára oznámenia';
 $labels['check_ok'] = 'Nastavenia tvojho prehliadača sú správne.';
 $labels['check_fail'] = 'Nebolo možné zobraziť upozornenie, kliknite na "Nakonfigurovať prehliadač"!';
 $labels['check_fail_blocked'] = 'Tvoj prehliadač blokoval upozornenie, prosím, nastav právomoci v prehliadači!';


### PR DESCRIPTION
This modification had an input text field to manage directories that cannot be parsed by notifier (such as Trash or Spam).
NB: French and English translations are rights, others using google translation.

Ty for your job on this plugin.
