### PR TITLE
Optionally notify only about *new* messages

### DIFF
--- a/html5_notifier.php
+++ b/html5_notifier.php
@@ -41,8 +41,10 @@ class html5_notifier extends rcube_plugin
     {
         $RCMAIL = rcmail::get_instance();
 
+        $search = $RCMAIL->config->get('html5_notifier_only_new', false) ?'NEW'  : 'RECENT';
+
 		$RCMAIL->storage->set_mailbox($args['mailbox']);
-		$RCMAIL->storage->search($args['mailbox'], "RECENT", null);
+		$RCMAIL->storage->search($args['mailbox'], $search, null);
 		$msgs = (array) $RCMAIL->storage->list_headers($args['mailbox']);
 		$excluded_directories = preg_split("/(,|;| )+/", $RCMAIL->config->get('html5_notifier_excluded_directories'));
 
@@ -97,6 +99,13 @@ class html5_notifier extends rcube_plugin
                 'content' => $content,
             );
 
+            $check_only_new = new html_checkbox(array('name' => '_html5_notifier_only_new', 'id' => $field_id . '_only_new', 'value' => 1));
+            $content = $check_only_new->show($RCMAIL->config->get('html5_notifier_only_new', false));
+            $args['blocks']['new_message']['options']['html5_notifier_only_new'] = array(
+                'title' => html::label($field_id, Q($this->gettext('onlynew'))),
+                'content' => $content,
+            );
+
 			$field_id .= '_excluded';
 			$input_excluded = new html_inputfield(array('name' => '_html5_notifier_excluded_directories', 'id' => $field_id));
 			$args['blocks']['new_message']['options']['html5_notifier_excluded_directories'] = array(
@@ -113,6 +122,7 @@ class html5_notifier extends rcube_plugin
     {
         if($args['section'] == 'mailbox')
         {
+            $args['prefs']['html5_notifier_only_new'] = !empty($_POST['_html5_notifier_only_new']);
             $args['prefs']['html5_notifier_duration'] = get_input_value('_html5_notifier_duration', RCUBE_INPUT_POST);
 			$args['prefs']['html5_notifier_smbox'] = get_input_value('_html5_notifier_smbox', RCUBE_INPUT_POST);
 			$args['prefs']['html5_notifier_excluded_directories'] = get_input_value('_html5_notifier_excluded_directories', RCUBE_INPUT_POST);

--- a/localization/cs_CZ.inc
+++ b/localization/cs_CZ.inc
@@ -1,6 +1,7 @@
 <?php
 $labels = array();
 $labels['shownotifies'] = 'Oznámení na ploše';
+$labels['onlynew'] = 'Zobrazit pouze nové zprávy';
 $labels['conf_browser'] = 'Nastavit prohlížeč';
 $labels['test_browser'] = 'Test';
 $labels['excluded_directories'] = 'Neoznamovat nové zprávy ve složkách';

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -1,6 +1,7 @@
 <?php
 $labels = array();
 $labels['shownotifies'] = 'Desktop Benachrichtigungen';
+$labels['onlynew'] = 'Nur neue Nachrichten anzeigen';
 $labels['conf_browser'] = 'Browser einrichten';
 $labels['test_browser'] = 'Testen';
 $labels['excluded_directories'] = 'Von Benachrichtigung ausgeschlossene Ordner';

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -1,6 +1,7 @@
 <?php
 $labels = array();
 $labels['shownotifies'] = 'Desktop Notifications';
+$labels['onlynew'] = 'Show only new messages';
 $labels['conf_browser'] = 'Configure browser';
 $labels['test_browser'] = 'Test';
 $labels['excluded_directories'] = 'Notification\'s excluded directories';

--- a/localization/es_ES.inc
+++ b/localization/es_ES.inc
@@ -2,6 +2,7 @@
 //Thanks to David Perez www.closemarketing.es
 $labels = array();
 $labels['shownotifies'] = 'Notificaciones Escritorio';
+$labels['onlynew'] = 'Mostrar sólo los mensajes nuevos';
 $labels['conf_browser'] = 'Configurar Navegador';
 $labels['test_browser'] = 'Test';
 $labels['excluded_directories'] = 'Directorios notificaciones Excluidos';

--- a/localization/fr_FR.inc
+++ b/localization/fr_FR.inc
@@ -1,6 +1,7 @@
 ﻿<?php
 $labels = array();
 $labels['shownotifies'] = 'Notifications de bureau';
+$labels['onlynew'] = 'Notification seulement dès messages nouveaux';
 $labels['conf_browser'] = 'Configurer votre navigateur';
 $labels['test_browser'] = 'Test';
 $labels['excluded_directories'] = 'Répertoires exclus des notifications';

--- a/localization/ja_JP.inc
+++ b/localization/ja_JP.inc
@@ -1,6 +1,7 @@
 <?php
 $labels = array();
 $labels['shownotifies'] = 'デスクトップ通知';
+$labels['onlynew'] = '新しいメッセージだけを表示する';
 $labels['conf_browser'] = 'ブラウザの設定';
 $labels['test_browser'] = 'テスト';
 $labels['excluded_directories'] = '通知から除外するディレクトリ';

--- a/localization/nl_NL.inc
+++ b/localization/nl_NL.inc
@@ -1,6 +1,7 @@
 <?php
 $labels = array();
 $labels['shownotifies'] = 'Bureaubladmeldingen';
+$labels['onlynew'] = 'Alleen voor nieuwe berichten';
 $labels['conf_browser'] = 'Configureer browser';
 $labels['test_browser'] = 'Test';
 $labels['excluded_directories'] = 'Geen meldingen tonen voor volgende mappen';

--- a/localization/sk_SK.inc
+++ b/localization/sk_SK.inc
@@ -1,6 +1,7 @@
 <?php
 $labels = array();
 $labels['shownotifies'] = 'Upozornenia na pracovnej ploche';
+$labels['onlynew'] = 'Iba nové správy';
 $labels['conf_browser'] = 'Nakonfigurovať prehliadač';
 $labels['test_browser'] = 'Test';
 $labels['excluded_directories'] = 'Vylúčené adresára oznámenia';


### PR DESCRIPTION
Especially when moving a lot of messages between mailboxes, it is
nice if only new messages trigger notifications, not recent messages
that have been read already.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>