### PR TITLE
Solution to fix the error that notification didn't work.

### DIFF
--- a/html5_notifier.php
+++ b/html5_notifier.php
@@ -41,7 +41,9 @@ class html5_notifier extends rcube_plugin
     {
         $RCMAIL = rcmail::get_instance();
 
-        $search = $RCMAIL->config->get('html5_notifier_only_new', false) ?'NEW'  : 'RECENT';
+        //$search = $RCMAIL->config->get('html5_notifier_only_new', false) ?'NEW'  : 'RECENT';
+		$deleted = $RCMAIL->config->get('skip_deleted') ? 'UNDELETED ' : '';
+		$search  = $deleted . 'UNSEEN UID ' . $args['diff']['new'];
 
 		$RCMAIL->storage->set_mailbox($args['mailbox']);
 		$RCMAIL->storage->search($args['mailbox'], $search, null);


### PR DESCRIPTION
This makes the 'Show only new messages' setting redundant, but doesn't take the setting away.