### PR TITLE
PHP Notice: Only variables should be passed by reference in...

### DIFF
--- a/html5_notifier.php
+++ b/html5_notifier.php
@@ -50,7 +50,10 @@ class html5_notifier extends rcube_plugin
         $RCMAIL->storage->set_folder($args['mailbox']);
         $RCMAIL->storage->search($args['mailbox'], $search, null);
         $msgs = (array) $RCMAIL->storage->list_messages($args['mailbox']);
-        $excluded_directories = preg_split("/(,|;| )+/", $RCMAIL->config->get('html5_notifier_excluded_directories'));
+        $excluded_directories = array();
+        if (!empty($RCMAIL->config->get('html5_notifier_excluded_directories'))) {
+            $excluded_directories = preg_split("/(,|;| )+/", $RCMAIL->config->get('html5_notifier_excluded_directories'));
+        }
 
         foreach ($msgs as $msg) {
             $from = $msg->get('from');

--- a/html5_notifier.php
+++ b/html5_notifier.php
@@ -44,22 +44,27 @@ class html5_notifier extends rcube_plugin
         $RCMAIL = rcmail::get_instance();
 
         //$search = $RCMAIL->config->get('html5_notifier_only_new', false) ?'NEW'  : 'RECENT';
-		$deleted = $RCMAIL->config->get('skip_deleted') ? 'UNDELETED ' : '';
-		$search  = $deleted . 'UNSEEN UID ' . $args['diff']['new'];
+        $deleted = $RCMAIL->config->get('skip_deleted') ? 'UNDELETED ' : '';
+        $search  = $deleted . 'UNSEEN UID ' . $args['diff']['new'];
 
-		$RCMAIL->storage->set_folder($args['mailbox']);
-		$RCMAIL->storage->search($args['mailbox'], $search, null);
-		$msgs = (array) $RCMAIL->storage->list_messages($args['mailbox']);
-		$excluded_directories = preg_split("/(,|;| )+/", $RCMAIL->config->get('html5_notifier_excluded_directories'));
+        $RCMAIL->storage->set_folder($args['mailbox']);
+        $RCMAIL->storage->search($args['mailbox'], $search, null);
+        $msgs = (array) $RCMAIL->storage->list_messages($args['mailbox']);
+        $excluded_directories = preg_split("/(,|;| )+/", $RCMAIL->config->get('html5_notifier_excluded_directories'));
 
-		foreach ($msgs as $msg) {
-		    $from = $msg->get('from');
-			$mbox = '';
-			switch ($RCMAIL->config->get('html5_notifier_smbox')) {
-				case 1: $mbox = array_pop(explode('.', str_replace('INBOX.', '', $args['mailbox']))); break;
-				case 2: $mbox = str_replace('.', '/', str_replace('INBOX.', '', $args['mailbox'])); break;
-			}
-			$subject = ((!empty($mbox)) ? rcube_charset::convert($mbox, 'UTF7-IMAP') . ': ' : '') . $msg->get('subject');
+        foreach ($msgs as $msg) {
+            $from = $msg->get('from');
+            $mbox = '';
+            switch ($RCMAIL->config->get('html5_notifier_smbox')) {
+                case 1:
+                    $mbox = explode('.', str_replace('INBOX.', '', $args['mailbox']));
+                    $mbox = array_pop($mbox);
+                    break;
+                case 2:
+                    $mbox = str_replace('.', '/', str_replace('INBOX.', '', $args['mailbox']));
+                    break;
+            }
+            $subject = ((!empty($mbox)) ? rcube_charset::convert($mbox, 'UTF7-IMAP') . ': ' : '') . $msg->get('subject');
 
             if(strtolower($_SESSION['username']) == strtolower($RCMAIL->user->data['username']) && !in_array($args['mailbox'], $excluded_directories))
             {
@@ -72,7 +77,7 @@ class html5_notifier extends rcube_plugin
                 ));
             }
         }
-		$RCMAIL->storage->search($args['mailbox'], "ALL", null);
+        $RCMAIL->storage->search($args['mailbox'], "ALL", null);
     }
     
     function prefs_list($args)
@@ -82,21 +87,21 @@ class html5_notifier extends rcube_plugin
             $RCMAIL = rcmail::get_instance();
               
             $field_id = 'rcmfd_html5_notifier'; 
-			
+            
             $select_duration = new html_select(array('name' => '_html5_notifier_duration', 'id' => $field_id));
             $select_duration->add($this->gettext('off'), '0');
             $times = array('3', '5', '8', '10', '12', '15', '20', '25', '30');
             foreach ($times as $time)
                 $select_duration->add($time.' '.$this->gettext('seconds'), $time);
             $select_duration->add($this->gettext('durable'), '-1');
-			
-			$select_smbox = new html_select(array('name' => '_html5_notifier_smbox', 'id' => $field_id));
+            
+            $select_smbox = new html_select(array('name' => '_html5_notifier_smbox', 'id' => $field_id));
             $select_smbox->add($this->gettext('no_mailbox'), '0');
-			$select_smbox->add($this->gettext('short_mailbox'), '1');
-			$select_smbox->add($this->gettext('full_mailbox'), '2');
+            $select_smbox->add($this->gettext('short_mailbox'), '1');
+            $select_smbox->add($this->gettext('full_mailbox'), '2');
 
             $content = $select_duration->show($RCMAIL->config->get('html5_notifier_duration').'');
-			$content .= $select_smbox->show($RCMAIL->config->get('html5_notifier_smbox').'');
+            $content .= $select_smbox->show($RCMAIL->config->get('html5_notifier_smbox').'');
             $content .= html::a(array('href' => '#', 'id' => 'rcmfd_html5_notifier_browser_conf', 'onclick' => 'rcmail_browser_notifications(); return false;'), $this->gettext('conf_browser')).' ';
             $content .= html::a(array('href' => '#', 'onclick' => 'rcmail_browser_notifications_test(); return false;'), $this->gettext('test_browser'));
             $args['blocks']['new_message']['options']['html5_notifier'] = array( 
@@ -111,19 +116,19 @@ class html5_notifier extends rcube_plugin
                 'content' => $content,
             );
 
-			$input_excluded = new html_inputfield(array('name' => '_html5_notifier_excluded_directories', 'id' => $field_id . '_excluded'));
-			$args['blocks']['new_message']['options']['html5_notifier_excluded_directories'] = array(
+            $input_excluded = new html_inputfield(array('name' => '_html5_notifier_excluded_directories', 'id' => $field_id . '_excluded'));
+            $args['blocks']['new_message']['options']['html5_notifier_excluded_directories'] = array(
                 'title' => html::label($field_id, rcube::Q($this->gettext('excluded_directories'))),
                 'content' => $input_excluded->show($RCMAIL->config->get('html5_notifier_excluded_directories').''),
             );
             
-			$select_type = new html_select(array('name' => '_html5_notifier_popuptype', 'id' => $field_id . '_popuptype'));
-			$select_type->add($this->gettext('new_tab'), '0');
-			$select_type->add($this->gettext('new_window'), '1');
-			$args['blocks']['new_message']['options']['html5_notifier_popuptype'] = array(
-				'title' => html::label($field_id, rcube::Q($this->gettext('notifier_popuptype'))),
-				'content' => $select_type->show($RCMAIL->config->get('html5_notifier_popuptype').'')
-			);
+            $select_type = new html_select(array('name' => '_html5_notifier_popuptype', 'id' => $field_id . '_popuptype'));
+            $select_type->add($this->gettext('new_tab'), '0');
+            $select_type->add($this->gettext('new_window'), '1');
+            $args['blocks']['new_message']['options']['html5_notifier_popuptype'] = array(
+                'title' => html::label($field_id, rcube::Q($this->gettext('notifier_popuptype'))),
+                'content' => $select_type->show($RCMAIL->config->get('html5_notifier_popuptype').'')
+            );
 
             $RCMAIL->output->add_script("$(document).ready(function(){ rcmail_browser_notifications_colorate(); });");
         }
@@ -136,10 +141,10 @@ class html5_notifier extends rcube_plugin
         {
             $args['prefs']['html5_notifier_only_new'] = !empty($_POST['_html5_notifier_only_new']);
             $args['prefs']['html5_notifier_duration'] = rcube_utils::get_input_value('_html5_notifier_duration', rcube_utils::INPUT_POST);
-			$args['prefs']['html5_notifier_smbox'] = rcube_utils::get_input_value('_html5_notifier_smbox', rcube_utils::INPUT_POST);
-			$args['prefs']['html5_notifier_excluded_directories'] = rcube_utils::get_input_value('_html5_notifier_excluded_directories', rcube_utils::INPUT_POST);
-			$args['prefs']['html5_notifier_popuptype'] = rcube_utils::get_input_value('_html5_notifier_popuptype', rcube_utils::INPUT_POST);
-			return $args;
+            $args['prefs']['html5_notifier_smbox'] = rcube_utils::get_input_value('_html5_notifier_smbox', rcube_utils::INPUT_POST);
+            $args['prefs']['html5_notifier_excluded_directories'] = rcube_utils::get_input_value('_html5_notifier_excluded_directories', rcube_utils::INPUT_POST);
+            $args['prefs']['html5_notifier_popuptype'] = rcube_utils::get_input_value('_html5_notifier_popuptype', rcube_utils::INPUT_POST);
+            return $args;
         }
     }
 }

--- a/localization/pt_PT.inc
+++ b/localization/pt_PT.inc
@@ -1,0 +1,26 @@
+<?php
+$labels = array();
+$labels['shownotifies'] = 'Notificações no Ambiente de trabalho';
+$labels['onlynew'] = 'Mostrar apenas novas mensagens';
+$labels['conf_browser'] = 'Configurar o navegador';
+$labels['test_browser'] = 'Testar';
+$labels['excluded_directories'] = 'Pastas excluídas das notificações';
+$labels['check_ok'] = 'As definições do seu navegador estão corretas.';
+$labels['check_fail'] = 'Não foi possível mostrar a notificação, clique em "Configurar o navegador"!';
+$labels['check_fail_blocked'] = 'O seu navegador bloqueou a notificação, ative a permissão nas definições do navegador!';
+$labels['no_notifications'] = 'O seu navegador não suporta Notificações no Ambiente de trabalho!';
+$labels['ok_notifications'] = 'A página já obteve permissão. As Notificações no Ambiente de trabalho devem funcionar.';
+$labels['notification_title'] = 'Novo e-mail de [from]';
+
+$labels['seconds'] = 'segundos';
+$labels['off'] = 'desativado';
+$labels['durable'] = 'permanente';
+
+$labels['no_mailbox'] = 'não mostrar caixa de correio';
+$labels['short_mailbox'] = 'mostrar caixa de correio curta';
+$labels['full_mailbox'] = 'mostrar caixa de correio completa';
+
+$labels['notifier_popuptype'] = 'Como abrir mensagens ao clicar na notificação';
+$labels['new_tab'] = 'Numa nova aba';
+$labels['new_window'] = 'Numa nova janela';
+?>


### PR DESCRIPTION
The `array_pop()` function's parameter is passed "by reference", meaning the function directly modifies the variable that is passed into the function https://github.com/stremlau/html5_notifier/blob/5d85947e16ea9cac4544c59666fe0ff13ba2a44a/html5_notifier.php#L59

Due to this behaviour, you can't pass a function directly into `array_pop()`, you have to store the output of `explode()` into a variable first, then pass that variable into `array_pop()`.

source: https://stackoverflow.com/a/45109918/924855

Note: also replaced indentation tabs with spaces, it was a mix of both.