### PR TITLE
Update html5_notifier for RC v1.7

### DIFF
--- a/html5_notifier.php
+++ b/html5_notifier.php
@@ -18,7 +18,7 @@ class html5_notifier extends rcube_plugin
     {
         $RCMAIL = rcmail::get_instance();
 
-        if(file_exists("./plugins/html5_notifier/config/config.inc.php"))
+        if(file_exists("../plugins/html5_notifier/config/config.inc.php"))
         {
             $this->load_config('config/config.inc.php');
         }


### PR DESCRIPTION
public_html/ is now the 'root' folder, the plugins/ folder is a level back, so must use ../ instead of ./